### PR TITLE
Fixed trains not unloading lumber at power plants.

### DIFF
--- a/mods/minegistics/src/items.lua
+++ b/mods/minegistics/src/items.lua
@@ -5,6 +5,11 @@
     License: AGPLv3
 ]]--
 
+fuels = {
+      "basenodes:coal_lump",
+      "basenodes:planks"
+}
+
 resources = {
       "basenodes:coal_lump",
       "basenodes:copper_lump",
@@ -17,7 +22,7 @@ resources = {
       "minegistics:meat_resource",
       "minegistics:vessels_milk_bottle_resource",
       "basenodes:planks"
-  }
+}
 
 products = {
     ["basenodes:coal_lump"] = "minegistics:coal_product",

--- a/mods/minegistics_trains/train_entity.lua
+++ b/mods/minegistics_trains/train_entity.lua
@@ -442,14 +442,13 @@ local function structure_check(self, dtime)
                 end
             elseif structure_name == "power_plant" then
                 local contents = direction:get_inventory()
-                for i, lump in pairs(resources) do
-                    if self.trainInv["basenodes:coal_lump"] == nil then
-                        self.trainInv["basenodes:coal_lump"] = 0
+                for i, fuel in pairs(fuels) do
+                    if self.trainInv[fuel] == nil then
+                        self.trainInv[fuel] = 0
                     end
-                    if self.trainInv["basenodes:coal_lump"] > 0 then
-                        contents:add_item("main", "basenodes:coal_lump" ..
-                            " " .. self.trainInv["basenodes:coal_lump"])
-                        self.trainInv["basenodes:coal_lump"] =  0
+                    if self.trainInv[fuel] > 0 then
+                        contents:add_item("main", fuel .. " " .. self.trainInv[fuel])
+                        self.trainInv[fuel] =  0
                     end
                 end
                 empty_train(self)


### PR DESCRIPTION
Trains were not unloading wood at power plants.

Anything meant to be fuel for the power plant can now be added to the fuels table in items.lua and trains will unload that item when they arrive at a power plant.